### PR TITLE
Mac build and various typos corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Falls eure Mod nicht richtig erkannt wird könnt ihr dass beheben in dem ihr ein
 https://github.com/NeonCrafter13/Transport-Fever-2-NeonModManager/blob/v1.3/example/mod.json und diesen in eure Mod packt.
 
 :uk:
-### What you can do with this Apllication:
+### What you can do with this Application:
 
 List all installed Mods,
 Search your installed Mods,
@@ -31,7 +31,7 @@ Open a Mod in Explorer,
 Uninstall a Mod,
 export modlists,
 compare modlists with installed mods.
-To run this apllication you need 7-Zip.
+To run this application you need 7-Zip.
 
 
 
@@ -54,10 +54,10 @@ Ihr werdet Eingabe-Felder sehen in diese gebt ihr den dazu gehörigen Pfad ein, 
 
 :uk:
 ### Windows
-For installation under Windows download the Windows realease via Github.https://github.com/NeonCrafter13/Transport-Fever-2-NeonModManager/releases/latest).
+For installation under Windows download the Windows release via GitHub.https://github.com/NeonCrafter13/Transport-Fever-2-NeonModManager/releases/latest).
 You also need to install 7-zip.
 Extract the zip file and start main.exe.
-You will see entry in which you can type the path to the correct folder, or you click on the button on the right of the entry for opening the directory. When you did this for all entrys click on `Continue`. After that click on `Continue`. Restart the Program afterwards.
+You will see a field in which you can type the path to the correct folder, or you click on the button on the right of the field to navigate to the directory. When you have done this for all the fields, click `Continue`. After that click on `Continue`. Restart the Program afterwards.
 
 ### Linux Debian based Systems
 Go to the last release(https://github.com/NeonCrafter13/Transport-Fever-2-NeonModManager/releases/latest) and download the .deb file. Click on the file and hit install. You will be requiered to type in you're Password.

--- a/mac_build.sh
+++ b/mac_build.sh
@@ -1,0 +1,4 @@
+pushd ./src || exit
+python ./package.py bdist_mac || true
+codesign -f -s willwill2will@gmail.com --deep ./build/*.app || true
+popd || exit

--- a/src/Tpf2-NeonModManager.spec
+++ b/src/Tpf2-NeonModManager.spec
@@ -1,6 +1,6 @@
 Summary: A Mod Manager for Transport-Fever 2
 Name: Tpf2-NeonModManager
-Version: 1.8.1
+Version: 1.11
 Release: 1
 License: GPLv3
 URL: https://github.com/NeonCrafter13/Transport-Fever-2-NeonModManager

--- a/src/freezeutils.py
+++ b/src/freezeutils.py
@@ -1,0 +1,13 @@
+import sys
+import os
+
+
+def find_data_file(filename):
+    if getattr(sys, "frozen", False):
+        # The application is frozen
+        datadir = os.path.dirname(sys.executable)
+    else:
+        # The application is not frozen
+        # Change this bit to match where you store your data files:
+        datadir = os.path.dirname(__file__)
+    return os.path.join(datadir, filename)

--- a/src/images.py
+++ b/src/images.py
@@ -1,15 +1,18 @@
 from PIL import Image
+from freezeutils import find_data_file as f
 
 import numpy as np
+
+
 def invert_image(path):
     img = Image.open(path)
 
-    img_arry = np.array(img)
+    img_array = np.array(img)
 
     I_max = 255
 
-    img_arry = I_max - img_arry
+    img_array = I_max - img_array
 
-    inverted_img = Image.fromarray(img_arry)
+    inverted_img = Image.fromarray(img_array)
 
-    inverted_img.save(r"Image_negative.jpg")
+    inverted_img.save(f(r"Image_negative.jpg"))

--- a/src/mod_finder.py
+++ b/src/mod_finder.py
@@ -165,8 +165,8 @@ def getSteamMod(folder, language: str):
     source = "Steam"
 
     try:
-        image = open(os.path.join(folder, "workshop_preview.jpg"), "r")
-        image = os.path.join(folder, "workshop_preview.jpg")
+        with open(os.path.join(folder, "workshop_preview.jpg"), "r"):
+            image = os.path.join(folder, "workshop_preview.jpg")
     except FileNotFoundError:
         image = None
 

--- a/src/modinstaller.py
+++ b/src/modinstaller.py
@@ -3,17 +3,18 @@ import configparser
 import subprocess
 from distutils.dir_util import copy_tree
 from sys import platform
+from freezeutils import find_data_file as f
 
 
 config = configparser.ConfigParser()
-config.read("settings.ini")
+config.read(f("settings.ini"))
 
 userdataModsDirectory = os.path.normpath(config['DIRECTORY']['userdatamods'])
-sevenZipinstallation = os.path.normpath(config["DIRECTORY"]["7-zipInstallation"])
+sevenZipInstallation = os.path.normpath(config["DIRECTORY"]["7-zipInstallation"])
 
 def install(link):
 
-    if platform == "linux":
+    if platform in ("linux", "darwin"):
         if link.lower().endswith('zip') or link.lower().endswith('rar') or link.lower().endswith("7z"):
             subprocess.Popen(["7z", "x", link, f"-o{userdataModsDirectory}", "-y"])
             return True
@@ -24,7 +25,7 @@ def install(link):
 
     elif platform == "win32":
         if link.lower().endswith('zip') or link.lower().endswith('rar') or link.lower().endswith("7z"):
-            subprocess.Popen(f'"{ os.path.join(sevenZipinstallation, "7z.exe") }" x {link} -o"{userdataModsDirectory}" -y')
+            subprocess.Popen(f'"{ os.path.join(sevenZipInstallation, "7z.exe") }" x {link} -o"{userdataModsDirectory}" -y')
             return True
         if os.path.isdir(link):
             # copy subdirectory example

--- a/src/modlist.py
+++ b/src/modlist.py
@@ -1,12 +1,14 @@
 import os
 import csv
 
+
 def export_modlist(mods, dir: str):
     with open(os.path.join(dir, 'modlist.csv'), 'w', encoding='utf-8') as file:
         writer = csv.writer(file)
         writer.writerow(["name", "source", "authors"])  # Row at the top for info
         for mod in mods:
             writer.writerow([mod.name, mod.source, mod.authors])
+
 
 def import_modlist(mods, file_path: str):
     try:

--- a/src/package.py
+++ b/src/package.py
@@ -1,0 +1,34 @@
+import sys
+from cx_Freeze import setup, Executable
+
+# Dependencies are automatically detected, but it might need fine tuning.
+resources = [
+    ('./images', './images'),
+    ('./modlist.json', './modlist.json'),
+    ('./settings.ini', './settings.ini'),
+    ('./aqua.css', './aqua.css'),
+]
+build_exe_options = {
+    'include_files': resources
+}
+
+build_mac_options = {
+    'iconfile': './images/Icon.icns',
+    'bundle_name': 'Transport Fever 2 NeonModManager',  # Name of the application: <name>.app
+    'codesign_identity': "willwill2will@gmail.com",
+    'codesign_deep': True
+}
+
+# GUI applications require a different base on Windows (the default is for
+# a console application).
+base = None
+if sys.platform == "win32":
+    base = "Win32GUI"
+
+setup(
+    name="Tpf2 NeonModManager",
+    version="1.11a1",
+    description="A little ModManager written in Python. See more info at https://github.com/NeonCrafter13/Transport-Fever-2-NeonModManager.",
+    options={'build_exe': build_exe_options, 'bdist_mac': build_mac_options},
+    executables=[Executable("main.py", base=base, target_name='NeonModManager')]
+)

--- a/src/package.py
+++ b/src/package.py
@@ -27,7 +27,7 @@ if sys.platform == "win32":
 
 setup(
     name="Tpf2 NeonModManager",
-    version="1.11a1",
+    version="1.11",
     description="A little ModManager written in Python. See more info at https://github.com/NeonCrafter13/Transport-Fever-2-NeonModManager.",
     options={'build_exe': build_exe_options, 'bdist_mac': build_mac_options},
     executables=[Executable("main.py", base=base, target_name='NeonModManager')]

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -1,10 +1,14 @@
 [DIRECTORY]
-externalmods = /home/marek/.steam/debian-installation/steamapps/common/Transport Fever 2/mods
-steammods = /home/marek/.steam/debian-installation/steamapps/workshop/content/1066780 
-userdatamods = /home/marek/.steam/debian-installation/userdata/436684792/1066780/local/mods
-stagingareamods = /home/marek/.steam/debian-installation/userdata/436684792/1066780/local/staging_area
-7-zipInstallation = /usr
+externalmods = foo
+steammods = foo
+userdatamods = foo
+stagingareamods = foo
+7-zipinstallation = /usr/local/bin
 
 [GRAPHICS]
 modernstyle = True
 imagesize = 384
+
+[LANGUAGE]
+language = en
+

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -8,7 +8,3 @@ stagingareamods = foo
 [GRAPHICS]
 modernstyle = True
 imagesize = 384
-
-[LANGUAGE]
-language = en
-

--- a/src/setup.py
+++ b/src/setup.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
     QCheckBox, QFileDialog, QHBoxLayout, QLabel, QLineEdit, QMainWindow, QPushButton, QVBoxLayout, QWidget
 )
 import configparser
+from freezeutils import find_data_file as f
 
 
 class Signals(QObject):
@@ -38,7 +39,7 @@ class Install_Window(QWidget):
         sig.submit.emit()
 
 
-class PathEnty(QWidget):
+class PathEntry(QWidget):
     def __init__(self, labeltext: str, tooltip: str, opentitle: str) -> None:
         super().__init__()
         self.labeltext = labeltext
@@ -81,7 +82,7 @@ class First(Install_Window):
 
     def fill_content(self):
         # Steam Mods
-        self.steam = PathEnty(
+        self.steam = PathEntry(
             "Set Steam Mods",
             "Example: /steamapps/workshop/content/1066780",
             "Open Steam Mods Folder"
@@ -89,7 +90,7 @@ class First(Install_Window):
         self.content.addWidget(self.steam)
 
         # Common Mods in settings.ini external
-        self.common = PathEnty(
+        self.common = PathEntry(
             "Set Common Mods",
             "Example: /steamapps/common/Transport Fever 2/mods",
             "open Common Mods Folder"
@@ -97,7 +98,7 @@ class First(Install_Window):
         self.content.addWidget(self.common)
 
         # Userdata Mods
-        self.userdata = PathEnty(
+        self.userdata = PathEntry(
             "Set Userdata Mods",
             "Example: /userdata/436684792/1066780/local/mods",
             "open userdata Mods Folder"
@@ -105,7 +106,7 @@ class First(Install_Window):
         self.content.addWidget(self.userdata)
 
         # Stagingarea Mods
-        self.stagingarea = PathEnty(
+        self.stagingarea = PathEntry(
             "Set Stagingarea",
             "Example: /userdata/436684792/1066780/local/staging_area",
             "open staging_area Folder"
@@ -114,7 +115,7 @@ class First(Install_Window):
 
         # 7-Zip installation
         if sys.platform == "win32":
-            self.sevenzip = PathEnty(
+            self.sevenzip = PathEntry(
                 "Set 7-Zip Installation",
                 r"Example: C:\Program Files\7-Zip",
                 "open 7-zip installation folder"
@@ -144,7 +145,7 @@ class First(Install_Window):
         config.add_section("LANGUAGE")
         config.set("LANGUAGE", "language", "en")
 
-        with open('settings.ini', 'w') as configfile:
+        with open(f('settings.ini'), 'w') as configfile:
             config.write(configfile)
 
         sig.next_page.emit()
@@ -156,7 +157,7 @@ class Second(Install_Window):
         self.build_gui()
 
     def build_gui(self):
-        self.content.addWidget(QLabel("Setup succesfull click on Continue to close the app."))
+        self.content.addWidget(QLabel("Setup successful click on Continue to close the app."))
         self.content.addWidget(
             QLabel("Restart the app afterwards"))
 
@@ -208,7 +209,7 @@ class Settings(Install_Window):
         self.continue_btn.setText("Apply and close")
         self.continue_btn.setToolTip("will close the application")
 
-        config.read("settings.ini")
+        config.read(f("settings.ini"))
 
         self.commonmodsdir = os.path.normpath(
             config['DIRECTORY']['externalMods'])
@@ -228,7 +229,7 @@ class Settings(Install_Window):
 
     def fill_content(self):
         # Steam Mods
-        self.steam = PathEnty(
+        self.steam = PathEntry(
             "Set Steam Mods",
             "Example: /steamapps/workshop/content/1066780",
             "Open Steam Mods Folder"
@@ -237,7 +238,7 @@ class Settings(Install_Window):
         self.content.addWidget(self.steam)
 
         # Common Mods in settings.ini external
-        self.common = PathEnty(
+        self.common = PathEntry(
             "Set Common Mods",
             "Example: /steamapps/common/Transport Fever 2/mods",
             "open Common Mods Folder"
@@ -246,7 +247,7 @@ class Settings(Install_Window):
         self.content.addWidget(self.common)
 
         # Userdata Mods
-        self.userdata = PathEnty(
+        self.userdata = PathEntry(
             "Set Userdata Mods",
             "Example: /userdata/436684792/1066780/local/mods",
             "open userdata Mods Folder"
@@ -255,7 +256,7 @@ class Settings(Install_Window):
         self.content.addWidget(self.userdata)
 
         # Stagingarea Mods
-        self.stagingarea = PathEnty(
+        self.stagingarea = PathEntry(
             "Set Stagingarea",
             "Example: /userdata/436684792/1066780/local/staging_area",
             "open staging_area Folder"
@@ -298,7 +299,7 @@ class Settings(Install_Window):
 
         config.set("LANGUAGE", "language", self.language.data.text())
 
-        with open('settings.ini', 'w') as configfile:
+        with open(f('settings.ini'), 'w') as configfile:
             config.write(configfile)
 
         # Quit App


### PR DESCRIPTION
Implemented cx_freeze-based macOS build, and threw in a whole bunch of proof-reading for free.

A change that will require attention moving forward is that all resource files (e.g. Aqua.css, settings.ini) must be addressed using the ```find_data_file()``` method from ```freezeutils.py```, currently imported as ```f()``` in those places where it is needed.